### PR TITLE
Closes ConnectSDK/Connect-SDK-Android-Core#70

### DIFF
--- a/src/com/connectsdk/discovery/provider/ssdp/SSDPClient.java
+++ b/src/com/connectsdk/discovery/provider/ssdp/SSDPClient.java
@@ -56,7 +56,7 @@ public class SSDPClient {
     public static final String BYEBYE = "ssdp:byebye";
     public static final String UPDATE = "ssdp:update";
 
-    DatagramSocket datagramSocket;
+    MulticastSocket datagramSocket;
     MulticastSocket multicastSocket;
 
     SocketAddress multicastGroup;
@@ -67,10 +67,10 @@ public class SSDPClient {
     static int MX = 5;
 
     public SSDPClient(InetAddress source) throws IOException {
-        this(source, new MulticastSocket(PORT), new DatagramSocket(null));
+        this(source, new MulticastSocket(PORT), new MulticastSocket(null));
     }
 
-    public SSDPClient(InetAddress source, MulticastSocket mcSocket, DatagramSocket dgSocket) throws IOException {
+    public SSDPClient(InetAddress source, MulticastSocket mcSocket, MulticastSocket dgSocket) throws IOException {
         localInAddress = source;
         multicastSocket = mcSocket;
         datagramSocket = dgSocket;
@@ -80,6 +80,7 @@ public class SSDPClient {
         multicastSocket.joinGroup(multicastGroup, networkInterface);
 
         datagramSocket.setReuseAddress(true);
+        datagramSocket.setTimeToLive(4);
         datagramSocket.bind(new InetSocketAddress(localInAddress, 0));
     }
 


### PR DESCRIPTION
Use multicast packages not datagrams
set ttl to 4 instead of 1 to allow traversal past internal routers
allows detection of devices when there is more than one router between the sender and receiver.  This is often the case in home networks where a wireless router is used as a wifi access point.
