### PR TITLE
Request/single instance

### DIFF
--- a/src/com/connectsdk/discovery/DiscoveryManager.java
+++ b/src/com/connectsdk/discovery/DiscoveryManager.java
@@ -145,7 +145,9 @@ public class DiscoveryManager implements ConnectableDeviceListener, DiscoveryPro
      @endcode
      */
     public static synchronized void init(Context context) {
-        instance = new DiscoveryManager(context);
+        if (instance == null) {
+            instance = new DiscoveryManager(context);
+        }
     }
 
     public static synchronized void destroy() {
@@ -163,7 +165,9 @@ public class DiscoveryManager implements ConnectableDeviceListener, DiscoveryPro
      @endcode
      */
     public static synchronized void init(Context context, ConnectableDeviceStore connectableDeviceStore) {
-        instance = new DiscoveryManager(context, connectableDeviceStore);
+        if (instance == null) {
+            instance = new DiscoveryManager(context, connectableDeviceStore);
+        }
     }
 
     /**
@@ -182,7 +186,7 @@ public class DiscoveryManager implements ConnectableDeviceListener, DiscoveryPro
      * Direct use of this constructor is not recommended. In most cases,
      * you should use DiscoveryManager.getInstance() instead.
      */
-    public DiscoveryManager(Context context) {
+    private DiscoveryManager(Context context) {
         this(context, new DefaultConnectableDeviceStore(context));
     }
 
@@ -191,7 +195,7 @@ public class DiscoveryManager implements ConnectableDeviceListener, DiscoveryPro
      * Direct use of this constructor is not recommended. In most cases,
      * you should use DiscoveryManager.getInstance() instead.
      */
-    public DiscoveryManager(Context context, ConnectableDeviceStore connectableDeviceStore) {
+    private DiscoveryManager(Context context, ConnectableDeviceStore connectableDeviceStore) {
         this.context = context;
         this.connectableDeviceStore = connectableDeviceStore;
 

--- a/src/com/connectsdk/discovery/provider/SSDPDiscoveryProvider.java
+++ b/src/com/connectsdk/discovery/provider/SSDPDiscoveryProvider.java
@@ -208,6 +208,12 @@ public class SSDPDiscoveryProvider implements DiscoveryProvider {
         if (executorService == null || executorService.isShutdown()) {
             Log.w(Util.T, "There are no filters added");
         } else {
+            if (executorService.isTerminated() || executorService.isShutdown()) {
+                if (serviceFilters != null && !serviceFilters.isEmpty()) {
+                    int poolSize = serviceFilters.size() * 3;
+                    executorService = Executors.newScheduledThreadPool(poolSize);
+                }
+            }
             for (DiscoveryFilter filter : serviceFilters) {
                 final String message = SSDPClient.getSSDPSearchMessage(filter.getServiceFilter());
                 /* Send 3 times like WindowsMedia */

--- a/src/com/connectsdk/discovery/provider/SSDPDiscoveryProvider.java
+++ b/src/com/connectsdk/discovery/provider/SSDPDiscoveryProvider.java
@@ -45,6 +45,9 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -70,7 +73,7 @@ public class SSDPDiscoveryProvider implements DiscoveryProvider {
 
     private Thread responseThread;
     private Thread notifyThread;
-
+    private ScheduledExecutorService executorService;
     boolean isRunning = false;
 
     public SSDPDiscoveryProvider(Context context) {
@@ -111,7 +114,11 @@ public class SSDPDiscoveryProvider implements DiscoveryProvider {
         isRunning = true;
 
         openSocket();
-
+        if (serviceFilters != null && !serviceFilters.isEmpty()) {
+            //three tasks for each service filter
+            int poolSize = serviceFilters.size() * 3;
+            executorService = Executors.newScheduledThreadPool(poolSize);
+        }
         scanTimer = new Timer();
         scanTimer.schedule(new TimerTask() {
 
@@ -177,6 +184,10 @@ public class SSDPDiscoveryProvider implements DiscoveryProvider {
             ssdpClient.close();
             ssdpClient = null;
         }
+
+        if (executorService != null && !executorService.isShutdown()) {
+            executorService.shutdown();
+        }
     }
 
     @Override
@@ -194,26 +205,25 @@ public class SSDPDiscoveryProvider implements DiscoveryProvider {
 
     @Override
     public void rescan() {
-        for (DiscoveryFilter searchTarget : serviceFilters) {
-            final String message = SSDPClient.getSSDPSearchMessage(searchTarget.getServiceFilter());
-
-            Timer timer = new Timer();
-            /* Send 3 times like WindowsMedia */
-            for (int i = 0; i < 3; i++) {
-                TimerTask task = new TimerTask() {
-
-                    @Override
-                    public void run() {
-                        try {
-                            if (ssdpClient != null)
-                                ssdpClient.send(message);
-                        } catch (IOException e) {
-                            e.printStackTrace();
+        if (executorService == null || executorService.isShutdown()) {
+            Log.w(Util.T, "There are no filters added");
+        } else {
+            for (DiscoveryFilter filter : serviceFilters) {
+                final String message = SSDPClient.getSSDPSearchMessage(filter.getServiceFilter());
+                /* Send 3 times like WindowsMedia */
+                for (int i = 0; i < 3; i++) {
+                    executorService.schedule(new Runnable() {
+                        @Override
+                        public void run() {
+                            try {
+                                if (ssdpClient != null)
+                                    ssdpClient.send(message);
+                            } catch (IOException ex) {
+                                Log.e(Util.T, ex.getMessage());
+                            }
                         }
-                    }
-                };
-
-                timer.schedule(task, i * 1000);
+                    }, i, TimeUnit.SECONDS);
+                }
             }
         }
 

--- a/src/com/connectsdk/discovery/provider/ZeroconfDiscoveryProvider.java
+++ b/src/com/connectsdk/discovery/provider/ZeroconfDiscoveryProvider.java
@@ -20,6 +20,16 @@
 
 package com.connectsdk.discovery.provider;
 
+import android.content.Context;
+import android.text.TextUtils;
+import android.util.Log;
+
+import com.connectsdk.core.Util;
+import com.connectsdk.discovery.DiscoveryFilter;
+import com.connectsdk.discovery.DiscoveryProvider;
+import com.connectsdk.discovery.DiscoveryProviderListener;
+import com.connectsdk.service.config.ServiceDescription;
+
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -34,15 +44,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import javax.jmdns.JmDNS;
 import javax.jmdns.ServiceEvent;
 import javax.jmdns.ServiceListener;
-
-import android.content.Context;
-import android.util.Log;
-
-import com.connectsdk.core.Util;
-import com.connectsdk.discovery.DiscoveryFilter;
-import com.connectsdk.discovery.DiscoveryProvider;
-import com.connectsdk.discovery.DiscoveryProviderListener;
-import com.connectsdk.service.config.ServiceDescription;
 
 public class ZeroconfDiscoveryProvider implements DiscoveryProvider {
     private static final String HOSTNAME = "connectsdk";
@@ -216,7 +217,9 @@ public class ZeroconfDiscoveryProvider implements DiscoveryProvider {
         if (jmdns != null) {
             for (DiscoveryFilter searchTarget : serviceFilters) {
                 String filter = searchTarget.getServiceFilter();
-                jmdns.removeServiceListener(filter, jmdnsListener);
+                if (!TextUtils.isEmpty(filter)) {
+                    jmdns.removeServiceListener(filter, jmdnsListener);
+                }
             }
         }
     }
@@ -245,7 +248,9 @@ public class ZeroconfDiscoveryProvider implements DiscoveryProvider {
             if (jmdns != null) {
                 for (DiscoveryFilter searchTarget : serviceFilters) {
                     String filter = searchTarget.getServiceFilter();
-                    jmdns.addServiceListener(filter, jmdnsListener);
+                    if (!TextUtils.isEmpty(filter)) {
+                        jmdns.addServiceListener(filter, jmdnsListener);
+                    }
                 }
             }
         } catch (IOException e) {

--- a/src/com/connectsdk/service/DIALService.java
+++ b/src/com/connectsdk/service/DIALService.java
@@ -54,6 +54,7 @@ public class DIALService extends DeviceService implements Launcher {
 
     public static final String ID = "DIAL";
     private static final String APP_NETFLIX = "Netflix";
+    private static final String APP_YOUTUBE = "YouTube";
 
     private static List<String> registeredApps = new ArrayList<String>();
 
@@ -206,9 +207,9 @@ public class DIALService extends DeviceService implements Launcher {
     @Override
     public void launchYouTube(String contentId, float startTime, AppLaunchListener listener) {
         String params = null;
-        AppInfo appInfo = new AppInfo("YouTube");
+        AppInfo appInfo = new AppInfo(APP_YOUTUBE);
         appInfo.setName(appInfo.getId());
-
+        JSONObject jsonParams = null;
         if (contentId != null && contentId.length() > 0) {
             if (startTime < 0.0) {
                 if (listener != null) {
@@ -219,6 +220,16 @@ public class DIALService extends DeviceService implements Launcher {
             }
 
             String pairingCode = java.util.UUID.randomUUID().toString();
+            /*
+            jsonParams = new JSONObject();
+            try {
+                //jsonParams.put("pairingCode", pairingCode);
+                jsonParams.put("v", contentId);
+                jsonParams.put("t", startTime);
+            } catch (JSONException e) {
+                Log.e(Util.T, "Launch YouTube error", e);
+            }
+            */
             params = String.format(Locale.US, "pairingCode=%s&v=%s&t=%.1f", pairingCode, contentId, startTime);
         }
 

--- a/test/src/com/connectsdk/core/MediaInfoTest.java
+++ b/test/src/com/connectsdk/core/MediaInfoTest.java
@@ -19,16 +19,18 @@
  */
 package com.connectsdk.core;
 
+import com.connectsdk.BuildConfig;
+
 import junit.framework.Assert;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
 
 
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, sdk = 21)
 public class MediaInfoTest {
 
     @Test

--- a/test/src/com/connectsdk/core/MediaInfoTest.java
+++ b/test/src/com/connectsdk/core/MediaInfoTest.java
@@ -26,8 +26,9 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE)
+
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class)
 public class MediaInfoTest {
 
     @Test

--- a/test/src/com/connectsdk/core/SubtitleInfoTest.java
+++ b/test/src/com/connectsdk/core/SubtitleInfoTest.java
@@ -27,8 +27,8 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE)
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class)
 public class SubtitleInfoTest {
 
     @Test

--- a/test/src/com/connectsdk/core/SubtitleInfoTest.java
+++ b/test/src/com/connectsdk/core/SubtitleInfoTest.java
@@ -19,16 +19,18 @@
  */
 package com.connectsdk.core;
 
+import com.connectsdk.BuildConfig;
+
 import junit.framework.Assert;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
 
 
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, sdk = 21)
 public class SubtitleInfoTest {
 
     @Test

--- a/test/src/com/connectsdk/device/ConnectableDeviceTest.java
+++ b/test/src/com/connectsdk/device/ConnectableDeviceTest.java
@@ -1,5 +1,6 @@
 package com.connectsdk.device;
 
+import com.connectsdk.BuildConfig;
 import com.connectsdk.discovery.DiscoveryManager;
 import com.connectsdk.service.AirPlayService;
 import com.connectsdk.service.DIALService;
@@ -19,8 +20,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 import java.io.IOException;
@@ -28,14 +29,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, sdk = 21)
 public class ConnectableDeviceTest {
 
     private ConnectableDevice device;
 
     @Before
     public void setUp() {
-        DiscoveryManager.init(Robolectric.application);
+        DiscoveryManager.init(RuntimeEnvironment.application);
         device = new ConnectableDevice();
     }
 

--- a/test/src/com/connectsdk/device/ConnectableDeviceTest.java
+++ b/test/src/com/connectsdk/device/ConnectableDeviceTest.java
@@ -27,8 +27,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE)
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class)
 public class ConnectableDeviceTest {
 
     private ConnectableDevice device;

--- a/test/src/com/connectsdk/discovery/DiscoveryManagerTest.java
+++ b/test/src/com/connectsdk/discovery/DiscoveryManagerTest.java
@@ -29,7 +29,8 @@ public class DiscoveryManagerTest {
     
     @Before
     public void setUp() {
-        discovery = new DiscoveryManager(RuntimeEnvironment.application);
+        DiscoveryManager.init(RuntimeEnvironment.application);
+        discovery = DiscoveryManager.getInstance();
     }
     
     @Test

--- a/test/src/com/connectsdk/discovery/DiscoveryManagerTest.java
+++ b/test/src/com/connectsdk/discovery/DiscoveryManagerTest.java
@@ -1,5 +1,6 @@
 package com.connectsdk.discovery;
 
+import com.connectsdk.BuildConfig;
 import com.connectsdk.discovery.provider.SSDPDiscoveryProvider;
 import com.connectsdk.discovery.provider.ZeroconfDiscoveryProvider;
 import com.connectsdk.service.DIALService;
@@ -10,8 +11,8 @@ import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 import java.util.Objects;
@@ -21,14 +22,14 @@ import java.util.Objects;
  */
 
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, sdk = 21)
 public class DiscoveryManagerTest {
     
     DiscoveryManager discovery;
     
     @Before
     public void setUp() {
-        discovery = new DiscoveryManager(Robolectric.application);
+        discovery = new DiscoveryManager(RuntimeEnvironment.application);
     }
     
     @Test
@@ -48,7 +49,7 @@ public class DiscoveryManagerTest {
 
     @Test
     public void testUnregisterDeviceServiceWithWrongProvider() {
-        discovery.discoveryProviders.add(new SSDPDiscoveryProvider(Robolectric.application));
+        discovery.discoveryProviders.add(new SSDPDiscoveryProvider(RuntimeEnvironment.application));
         discovery.deviceClasses.put(DIALService.ID, DIALService.class);
         Assert.assertEquals(1, discovery.discoveryProviders.size());
         Assert.assertEquals(1, discovery.deviceClasses.size());
@@ -60,7 +61,7 @@ public class DiscoveryManagerTest {
 
     @Test
     public void testUnregisterDeviceServiceWithWrongServiceID() {
-        discovery.discoveryProviders.add(new SSDPDiscoveryProvider(Robolectric.application));
+        discovery.discoveryProviders.add(new SSDPDiscoveryProvider(RuntimeEnvironment.application));
         discovery.deviceClasses.put(DLNAService.ID, DIALService.class);
         Assert.assertEquals(1, discovery.discoveryProviders.size());
         Assert.assertEquals(1, discovery.deviceClasses.size());
@@ -72,7 +73,7 @@ public class DiscoveryManagerTest {
     
     @Test
     public void testUnregisterDeviceService() {
-        discovery.discoveryProviders.add(new SSDPDiscoveryProvider(Robolectric.application));
+        discovery.discoveryProviders.add(new SSDPDiscoveryProvider(RuntimeEnvironment.application));
         discovery.deviceClasses.put(DIALService.ID, DIALService.class);
         Assert.assertEquals(1, discovery.discoveryProviders.size());
         Assert.assertEquals(1, discovery.deviceClasses.size());

--- a/test/src/com/connectsdk/discovery/DiscoveryManagerTest.java
+++ b/test/src/com/connectsdk/discovery/DiscoveryManagerTest.java
@@ -20,8 +20,8 @@ import java.util.Objects;
  * Created by oleksii.frolov on 2/16/2015.
  */
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest=Config.NONE)
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class)
 public class DiscoveryManagerTest {
     
     DiscoveryManager discovery;

--- a/test/src/com/connectsdk/discovery/provider/SSDPDiscoveryProviderTest.java
+++ b/test/src/com/connectsdk/discovery/provider/SSDPDiscoveryProviderTest.java
@@ -30,8 +30,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest=Config.NONE,shadows={WifiInfoShadow.class})
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class, shadows={WifiInfoShadow.class})
 public class SSDPDiscoveryProviderTest{
 
 

--- a/test/src/com/connectsdk/discovery/provider/SSDPDiscoveryProviderTest.java
+++ b/test/src/com/connectsdk/discovery/provider/SSDPDiscoveryProviderTest.java
@@ -38,7 +38,7 @@ public class SSDPDiscoveryProviderTest{
     SSDPDiscoveryProvider dp;
     private SSDPClient ssdpClient = Mockito.mock(SSDPClient.class);
 
-    class StubSSDPDiscoveryProvider extends SSDPDiscoveryProvider {
+        class StubSSDPDiscoveryProvider extends SSDPDiscoveryProvider {
 
         public StubSSDPDiscoveryProvider(Context context) {
             super(context);

--- a/test/src/com/connectsdk/discovery/provider/SSDPDiscoveryProviderTest.java
+++ b/test/src/com/connectsdk/discovery/provider/SSDPDiscoveryProviderTest.java
@@ -2,6 +2,7 @@ package com.connectsdk.discovery.provider;
 
 import android.content.Context;
 
+import com.connectsdk.BuildConfig;
 import com.connectsdk.core.TestUtil;
 import com.connectsdk.discovery.DiscoveryFilter;
 import com.connectsdk.discovery.provider.ssdp.SSDPClient;
@@ -14,10 +15,9 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 import java.io.IOException;
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class, shadows={WifiInfoShadow.class})
+@Config(constants = BuildConfig.class, shadows={WifiInfoShadow.class}, sdk = 21)
 public class SSDPDiscoveryProviderTest{
 
 
@@ -57,7 +57,7 @@ public class SSDPDiscoveryProviderTest{
         byte[] data = new byte[1];
         when(ssdpClient.responseReceive()).thenReturn(new DatagramPacket(data, 1));
         when(ssdpClient.multicastReceive()).thenReturn(new DatagramPacket(data, 1));
-        dp = new StubSSDPDiscoveryProvider(Robolectric.application);
+        dp = new StubSSDPDiscoveryProvider(RuntimeEnvironment.application);
         assertNotNull(dp);
     }
     @After

--- a/test/src/com/connectsdk/discovery/provider/ZeroConfDiscoveryPrividerTest.java
+++ b/test/src/com/connectsdk/discovery/provider/ZeroConfDiscoveryPrividerTest.java
@@ -34,9 +34,8 @@ import com.connectsdk.discovery.DiscoveryProvider;
 import com.connectsdk.discovery.DiscoveryProviderListener;
 import com.connectsdk.service.config.ServiceDescription;
 import com.connectsdk.shadow.WifiInfoShadow;
-
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, shadows = { WifiInfoShadow.class })
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class, shadows = {WifiInfoShadow.class })
 public class ZeroConfDiscoveryPrividerTest {
 
     private ZeroconfDiscoveryProvider dp;

--- a/test/src/com/connectsdk/discovery/provider/ZeroConfDiscoveryPrividerTest.java
+++ b/test/src/com/connectsdk/discovery/provider/ZeroConfDiscoveryPrividerTest.java
@@ -1,12 +1,24 @@
 package com.connectsdk.discovery.provider;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import android.content.Context;
+
+import com.connectsdk.BuildConfig;
+import com.connectsdk.discovery.DiscoveryFilter;
+import com.connectsdk.discovery.DiscoveryManager;
+import com.connectsdk.discovery.DiscoveryProvider;
+import com.connectsdk.discovery.DiscoveryProviderListener;
+import com.connectsdk.service.config.ServiceDescription;
+import com.connectsdk.shadow.WifiInfoShadow;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowLooper;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -17,25 +29,15 @@ import javax.jmdns.ServiceInfo;
 import javax.jmdns.ServiceListener;
 import javax.jmdns.impl.JmDNSImpl;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mockito;
-import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
-
-import android.content.Context;
-
-import com.connectsdk.discovery.DiscoveryFilter;
-import com.connectsdk.discovery.DiscoveryManager;
-import com.connectsdk.discovery.DiscoveryProvider;
-import com.connectsdk.discovery.DiscoveryProviderListener;
-import com.connectsdk.service.config.ServiceDescription;
-import com.connectsdk.shadow.WifiInfoShadow;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class, shadows = {WifiInfoShadow.class })
+@Config(constants = BuildConfig.class, shadows = {WifiInfoShadow.class }, sdk = 21)
 public class ZeroConfDiscoveryPrividerTest {
 
     private ZeroconfDiscoveryProvider dp;
@@ -77,7 +79,7 @@ public class ZeroConfDiscoveryPrividerTest {
 
     @Before
     public void setUp() {
-        dp = new StubZeroConfDiscoveryProvider(Robolectric.application);
+        dp = new StubZeroConfDiscoveryProvider(RuntimeEnvironment.application);
         mDNS = mock(StubJmDNS.class);
         eventMock = mock(StubServiceEvent.class);
 
@@ -296,7 +298,7 @@ public class ZeroConfDiscoveryPrividerTest {
 
         // when
         dp.jmdnsListener.serviceRemoved(event);
-        Robolectric.runUiThreadTasksIncludingDelayedTasks();
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
 
         // then
         verify(listener).onServiceRemoved(any(DiscoveryProvider.class), any(ServiceDescription.class));

--- a/test/src/com/connectsdk/discovery/provider/ssdp/SSDPClientTest.java
+++ b/test/src/com/connectsdk/discovery/provider/ssdp/SSDPClientTest.java
@@ -22,8 +22,8 @@ import java.net.MulticastSocket;
 import java.net.NetworkInterface;
 import java.net.SocketAddress;
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest=Config.NONE ,shadows = { WifiInfoShadow.class })
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class, shadows = { WifiInfoShadow.class })
 public class SSDPClientTest {
 
     InetAddress localAddress;

--- a/test/src/com/connectsdk/discovery/provider/ssdp/SSDPClientTest.java
+++ b/test/src/com/connectsdk/discovery/provider/ssdp/SSDPClientTest.java
@@ -1,5 +1,6 @@
 package com.connectsdk.discovery.provider.ssdp;
 
+import com.connectsdk.BuildConfig;
 import com.connectsdk.core.Util;
 import com.connectsdk.shadow.WifiInfoShadow;
 
@@ -9,8 +10,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 import java.io.IOException;
@@ -23,7 +24,7 @@ import java.net.NetworkInterface;
 import java.net.SocketAddress;
 
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class, shadows = { WifiInfoShadow.class })
+@Config(constants = BuildConfig.class, shadows = { WifiInfoShadow.class }, sdk = 21)
 public class SSDPClientTest {
 
     InetAddress localAddress;
@@ -38,7 +39,7 @@ public class SSDPClientTest {
 
     @Before
     public void setUp() throws IOException {
-        localAddress = Util.getIpAddress(Robolectric.application);
+        localAddress = Util.getIpAddress(RuntimeEnvironment.application);
         ssdpClient = new SSDPClient(localAddress, mLocalSocket, wildSocket);
     }
 

--- a/test/src/com/connectsdk/discovery/provider/ssdp/SSDPPacketTest.java
+++ b/test/src/com/connectsdk/discovery/provider/ssdp/SSDPPacketTest.java
@@ -1,16 +1,18 @@
 package com.connectsdk.discovery.provider.ssdp;
 
+import com.connectsdk.BuildConfig;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.net.DatagramPacket;
 
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, sdk = 21)
 public class SSDPPacketTest {
 
     DatagramPacket mDatagramPacket;

--- a/test/src/com/connectsdk/discovery/provider/ssdp/SSDPPacketTest.java
+++ b/test/src/com/connectsdk/discovery/provider/ssdp/SSDPPacketTest.java
@@ -9,8 +9,8 @@ import org.robolectric.annotation.Config;
 
 import java.net.DatagramPacket;
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest=Config.NONE)
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class)
 public class SSDPPacketTest {
 
     DatagramPacket mDatagramPacket;

--- a/test/src/com/connectsdk/service/AirPlayServiceTest.java
+++ b/test/src/com/connectsdk/service/AirPlayServiceTest.java
@@ -20,8 +20,8 @@ import java.io.IOException;
 /**
  * Created by Oleksii Frolov on 3/19/2015.
  */
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE)
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class)
 public class AirPlayServiceTest {
 
     private StubAirPlayService service;

--- a/test/src/com/connectsdk/service/AirPlayServiceTest.java
+++ b/test/src/com/connectsdk/service/AirPlayServiceTest.java
@@ -1,5 +1,6 @@
 package com.connectsdk.service;
 
+import com.connectsdk.BuildConfig;
 import com.connectsdk.service.capability.MediaControl;
 import com.connectsdk.service.command.ServiceCommand;
 import com.connectsdk.service.command.ServiceCommandError;
@@ -12,7 +13,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.io.IOException;
@@ -21,7 +22,7 @@ import java.io.IOException;
  * Created by Oleksii Frolov on 3/19/2015.
  */
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, sdk = 21)
 public class AirPlayServiceTest {
 
     private StubAirPlayService service;

--- a/test/src/com/connectsdk/service/DIALServiceSendCommandTest.java
+++ b/test/src/com/connectsdk/service/DIALServiceSendCommandTest.java
@@ -41,9 +41,8 @@ import org.robolectric.annotation.Config;
 
 import java.io.IOException;
 
-
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE)
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class)
 public class DIALServiceSendCommandTest {
 
     public static final String COMMAND_URL = "http://host:8080/path";

--- a/test/src/com/connectsdk/service/DIALServiceSendCommandTest.java
+++ b/test/src/com/connectsdk/service/DIALServiceSendCommandTest.java
@@ -20,6 +20,7 @@
 
 package com.connectsdk.service;
 
+import com.connectsdk.BuildConfig;
 import com.connectsdk.core.TestUtil;
 import com.connectsdk.etc.helper.HttpConnection;
 import com.connectsdk.etc.helper.HttpMessage;
@@ -35,14 +36,14 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowLooper;
 
 import java.io.IOException;
 
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, sdk = 21)
 public class DIALServiceSendCommandTest {
 
     public static final String COMMAND_URL = "http://host:8080/path";
@@ -150,7 +151,7 @@ public class DIALServiceSendCommandTest {
 
         service.sendCommand(command);
         TestUtil.runUtilBackgroundTasks();
-        Robolectric.runUiThreadTasksIncludingDelayedTasks();
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
 
         Mockito.verify(listener).onSuccess(Mockito.eq(response));
     }
@@ -166,7 +167,7 @@ public class DIALServiceSendCommandTest {
 
         service.sendCommand(command);
         TestUtil.runUtilBackgroundTasks();
-        Robolectric.runUiThreadTasksIncludingDelayedTasks();
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
 
         Mockito.verify(listener).onSuccess(Mockito.eq(response));
     }
@@ -196,7 +197,7 @@ public class DIALServiceSendCommandTest {
 
         service.sendCommand(command);
         TestUtil.runUtilBackgroundTasks();
-        Robolectric.runUiThreadTasksIncludingDelayedTasks();
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
 
         Mockito.verify(listener).onError(Mockito.any(ServiceCommandError.class));
     }

--- a/test/src/com/connectsdk/service/DIALServiceTest.java
+++ b/test/src/com/connectsdk/service/DIALServiceTest.java
@@ -20,6 +20,7 @@
 
 package com.connectsdk.service;
 
+import com.connectsdk.BuildConfig;
 import com.connectsdk.service.capability.Launcher;
 import com.connectsdk.service.command.ServiceCommand;
 import com.connectsdk.service.config.ServiceConfig;
@@ -32,11 +33,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, sdk = 21)
 public class DIALServiceTest {
 
     private static final String APPLICATION_URL = "http://applicationurl";

--- a/test/src/com/connectsdk/service/DIALServiceTest.java
+++ b/test/src/com/connectsdk/service/DIALServiceTest.java
@@ -35,8 +35,8 @@ import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest=Config.NONE)
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class)
 public class DIALServiceTest {
 
     private static final String APPLICATION_URL = "http://applicationurl";

--- a/test/src/com/connectsdk/service/DLNAServiceSendCommandTest.java
+++ b/test/src/com/connectsdk/service/DLNAServiceSendCommandTest.java
@@ -42,8 +42,8 @@ import org.robolectric.annotation.Config;
 import java.io.IOException;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE)
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class)
 public class DLNAServiceSendCommandTest {
 
     public static final String COMMAND_URL = "http://host:8080/path";

--- a/test/src/com/connectsdk/service/DLNAServiceSendCommandTest.java
+++ b/test/src/com/connectsdk/service/DLNAServiceSendCommandTest.java
@@ -20,9 +20,9 @@
 
 package com.connectsdk.service;
 
+import com.connectsdk.BuildConfig;
 import com.connectsdk.core.TestUtil;
 import com.connectsdk.etc.helper.HttpConnection;
-import com.connectsdk.etc.helper.HttpMessage;
 import com.connectsdk.service.capability.listeners.ResponseListener;
 import com.connectsdk.service.command.ServiceCommand;
 import com.connectsdk.service.command.ServiceCommandError;
@@ -35,15 +35,15 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowLooper;
 
 import java.io.IOException;
 
 
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, sdk = 21)
 public class DLNAServiceSendCommandTest {
 
     public static final String COMMAND_URL = "http://host:8080/path";
@@ -104,7 +104,7 @@ public class DLNAServiceSendCommandTest {
 
         service.sendCommand(command);
         TestUtil.runUtilBackgroundTasks();
-        Robolectric.runUiThreadTasksIncludingDelayedTasks();
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
 
         Mockito.verify(httpConnection, Mockito.times(0)).execute();
         Mockito.verify(listener).onError(Mockito.any(ServiceCommandError.class));
@@ -121,7 +121,7 @@ public class DLNAServiceSendCommandTest {
 
         service.sendCommand(command);
         TestUtil.runUtilBackgroundTasks();
-        Robolectric.runUiThreadTasksIncludingDelayedTasks();
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
 
         Mockito.verify(httpConnection, Mockito.times(0)).execute();
         Mockito.verify(listener).onError(Mockito.any(ServiceCommandError.class));

--- a/test/src/com/connectsdk/service/DLNAServiceTest.java
+++ b/test/src/com/connectsdk/service/DLNAServiceTest.java
@@ -30,8 +30,8 @@ import java.util.Map;
 /**
  * Created by oleksii.frolov on 1/13/2015.
  */
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest=Config.NONE)
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class)
 public class DLNAServiceTest {
 
     private DLNAService service;

--- a/test/src/com/connectsdk/service/DLNAServiceTest.java
+++ b/test/src/com/connectsdk/service/DLNAServiceTest.java
@@ -1,5 +1,6 @@
 package com.connectsdk.service;
 
+import com.connectsdk.BuildConfig;
 import com.connectsdk.core.SubtitleInfo;
 import com.connectsdk.core.TestUtil;
 import com.connectsdk.discovery.provider.ssdp.Service;
@@ -15,8 +16,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 import org.xml.sax.SAXException;
 
@@ -31,7 +32,7 @@ import java.util.Map;
  * Created by oleksii.frolov on 1/13/2015.
  */
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, sdk = 21)
 public class DLNAServiceTest {
 
     private DLNAService service;
@@ -42,7 +43,7 @@ public class DLNAServiceTest {
     public void setUp() {
         dlnaServer = Mockito.mock(DLNAHttpServer.class);
         service = new DLNAService(Mockito.mock(ServiceDescription.class),
-                Mockito.mock(ServiceConfig.class), Robolectric.application, dlnaServer);
+                Mockito.mock(ServiceConfig.class), RuntimeEnvironment.application, dlnaServer);
     }
 
     @Test
@@ -446,7 +447,7 @@ public class DLNAServiceTest {
 
         ServiceDescription description = Mockito.mock(ServiceDescription.class);
         Mockito.when(description.getServiceList()).thenReturn(services);
-        return new DLNAService(description, Mockito.mock(ServiceConfig.class), Robolectric.application, null);
+        return new DLNAService(description, Mockito.mock(ServiceConfig.class), RuntimeEnvironment.application, null);
     }
 
     private void assertXMLEquals(String expectedXML, String actualXML) throws SAXException, IOException {

--- a/test/src/com/connectsdk/service/NetCastTVServiceTest.java
+++ b/test/src/com/connectsdk/service/NetCastTVServiceTest.java
@@ -22,8 +22,8 @@ import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE)
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class)
 public class NetCastTVServiceTest {
 
     private NetcastTVService service;

--- a/test/src/com/connectsdk/service/NetCastTVServiceTest.java
+++ b/test/src/com/connectsdk/service/NetCastTVServiceTest.java
@@ -1,12 +1,12 @@
 package com.connectsdk.service;
 
+import com.connectsdk.BuildConfig;
 import com.connectsdk.discovery.DiscoveryManager;
 import com.connectsdk.service.capability.CapabilityMethods;
 import com.connectsdk.service.capability.MediaControl;
 import com.connectsdk.service.capability.MediaPlayer;
 import com.connectsdk.service.capability.listeners.ResponseListener;
 import com.connectsdk.service.command.NotSupportedServiceCommandError;
-import com.connectsdk.service.command.ServiceCommand;
 import com.connectsdk.service.command.ServiceCommandError;
 import com.connectsdk.service.config.ServiceConfig;
 import com.connectsdk.service.config.ServiceDescription;
@@ -18,12 +18,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, sdk = 21)
 public class NetCastTVServiceTest {
 
     private NetcastTVService service;
@@ -135,7 +135,7 @@ public class NetCastTVServiceTest {
     }
 
     private void setPairingLevel(DiscoveryManager.PairingLevel level) {
-        DiscoveryManager.init(Robolectric.application);
+        DiscoveryManager.init(RuntimeEnvironment.application);
         DiscoveryManager.getInstance().setPairingLevel(level);
     }
 

--- a/test/src/com/connectsdk/service/RokuServiceTest.java
+++ b/test/src/com/connectsdk/service/RokuServiceTest.java
@@ -35,8 +35,8 @@ import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE)
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class)
 public class RokuServiceTest {
 
     private StubRokuService service;

--- a/test/src/com/connectsdk/service/RokuServiceTest.java
+++ b/test/src/com/connectsdk/service/RokuServiceTest.java
@@ -19,6 +19,7 @@
  */
 package com.connectsdk.service;
 
+import com.connectsdk.BuildConfig;
 import com.connectsdk.core.MediaInfo;
 import com.connectsdk.core.TestUtil;
 import com.connectsdk.service.capability.MediaPlayer;
@@ -32,11 +33,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, sdk = 21)
 public class RokuServiceTest {
 
     private StubRokuService service;

--- a/test/src/com/connectsdk/service/WebOSTVServiceTest.java
+++ b/test/src/com/connectsdk/service/WebOSTVServiceTest.java
@@ -19,6 +19,7 @@
  */
 package com.connectsdk.service;
 
+import com.connectsdk.BuildConfig;
 import com.connectsdk.core.ChannelInfo;
 import com.connectsdk.core.MediaInfo;
 import com.connectsdk.core.SubtitleInfo;
@@ -47,9 +48,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowLooper;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -57,7 +58,7 @@ import java.util.List;
 import java.util.Map;
 
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, sdk = 21)
 public class WebOSTVServiceTest {
 
     private WebOSTVService service;
@@ -452,7 +453,7 @@ public class WebOSTVServiceTest {
         // run join success
         ResponseListener webAppListener = argListener.getValue();
         webAppListener.onSuccess(null);
-        Robolectric.runUiThreadTasksIncludingDelayedTasks();
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
 
         // should delegate playing media to the WebAppSession
         ArgumentCaptor<MediaInfo> argMediaInfo = ArgumentCaptor.forClass(MediaInfo.class);

--- a/test/src/com/connectsdk/service/WebOSTVServiceTest.java
+++ b/test/src/com/connectsdk/service/WebOSTVServiceTest.java
@@ -56,8 +56,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest=Config.NONE)
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class)
 public class WebOSTVServiceTest {
 
     private WebOSTVService service;

--- a/test/src/com/connectsdk/service/airplay/PListParserTest.java
+++ b/test/src/com/connectsdk/service/airplay/PListParserTest.java
@@ -19,13 +19,15 @@
  */
 package com.connectsdk.service.airplay;
 
+import com.connectsdk.BuildConfig;
+
 import junit.framework.Assert;
 
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
 import org.xmlpull.v1.XmlPullParserException;
 
@@ -33,7 +35,7 @@ import java.io.IOException;
 
 
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, sdk = 21)
 public class PListParserTest {
 
     @Test

--- a/test/src/com/connectsdk/service/airplay/PListParserTest.java
+++ b/test/src/com/connectsdk/service/airplay/PListParserTest.java
@@ -32,8 +32,8 @@ import org.xmlpull.v1.XmlPullParserException;
 import java.io.IOException;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest=Config.NONE)
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class)
 public class PListParserTest {
 
     @Test

--- a/test/src/com/connectsdk/service/sessions/WebOSWebAppSessionTest.java
+++ b/test/src/com/connectsdk/service/sessions/WebOSWebAppSessionTest.java
@@ -47,8 +47,8 @@ import org.robolectric.annotation.Config;
 
 import android.support.annotation.NonNull;
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest=Config.NONE)
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class)
 public class WebOSWebAppSessionTest {
 
     private WebOSWebAppSession session;

--- a/test/src/com/connectsdk/service/sessions/WebOSWebAppSessionTest.java
+++ b/test/src/com/connectsdk/service/sessions/WebOSWebAppSessionTest.java
@@ -19,6 +19,9 @@
  */
 package com.connectsdk.service.sessions;
 
+import android.support.annotation.NonNull;
+
+import com.connectsdk.BuildConfig;
 import com.connectsdk.core.MediaInfo;
 import com.connectsdk.core.SubtitleInfo;
 import com.connectsdk.service.DeviceService;
@@ -41,14 +44,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
-
-import android.support.annotation.NonNull;
+import org.robolectric.shadows.ShadowLooper;
 
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, sdk = 21)
 public class WebOSWebAppSessionTest {
 
     private WebOSWebAppSession session;
@@ -73,7 +74,7 @@ public class WebOSWebAppSessionTest {
         ResponseListener<Object> listener = Mockito.mock(ResponseListener.class);
         session.previous(listener);
 
-        Robolectric.runUiThreadTasksIncludingDelayedTasks();
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
         ArgumentCaptor<JSONObject> argPacket = ArgumentCaptor.forClass(JSONObject.class);
         ArgumentCaptor<JSONObject> argPayload = ArgumentCaptor.forClass(JSONObject.class);
         Mockito.verify(socket).sendMessage(argPacket.capture(), argPayload.capture());
@@ -94,7 +95,7 @@ public class WebOSWebAppSessionTest {
         ResponseListener<Object> listener = Mockito.mock(ResponseListener.class);
         session.next(listener);
 
-        Robolectric.runUiThreadTasksIncludingDelayedTasks();
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
         ArgumentCaptor<JSONObject> argPacket = ArgumentCaptor.forClass(JSONObject.class);
         ArgumentCaptor<JSONObject> argPayload = ArgumentCaptor.forClass(JSONObject.class);
         Mockito.verify(socket).sendMessage(argPacket.capture(), argPayload.capture());
@@ -115,7 +116,7 @@ public class WebOSWebAppSessionTest {
         ResponseListener<Object> listener = Mockito.mock(ResponseListener.class);
         session.jumpToTrack(7, listener);
 
-        Robolectric.runUiThreadTasksIncludingDelayedTasks();
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
         ArgumentCaptor<JSONObject> argPacket = ArgumentCaptor.forClass(JSONObject.class);
         ArgumentCaptor<JSONObject> argPayload = ArgumentCaptor.forClass(JSONObject.class);
         Mockito.verify(socket).sendMessage(argPacket.capture(), argPayload.capture());

--- a/test/src/com/connectsdk/service/upnp/DLNAHttpServerTest.java
+++ b/test/src/com/connectsdk/service/upnp/DLNAHttpServerTest.java
@@ -1,19 +1,20 @@
 package com.connectsdk.service.upnp;
 
+import com.connectsdk.BuildConfig;
 import com.connectsdk.service.command.URLServiceSubscription;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
 
 /**
  * Created by oleksii on 4/27/15.
  */
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, sdk = 21)
 public class DLNAHttpServerTest {
 
     DLNAHttpServer server;

--- a/test/src/com/connectsdk/service/upnp/DLNAHttpServerTest.java
+++ b/test/src/com/connectsdk/service/upnp/DLNAHttpServerTest.java
@@ -12,8 +12,8 @@ import org.robolectric.annotation.Config;
 /**
  * Created by oleksii on 4/27/15.
  */
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest=Config.NONE)
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class)
 public class DLNAHttpServerTest {
 
     DLNAHttpServer server;

--- a/test/src/com/connectsdk/service/webos/WebOSTVServiceSocketClientTest.java
+++ b/test/src/com/connectsdk/service/webos/WebOSTVServiceSocketClientTest.java
@@ -17,8 +17,8 @@ import org.robolectric.annotation.Config;
 
 import java.net.URI;
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE)
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class)
 public class WebOSTVServiceSocketClientTest {
 
     private WebOSTVServiceSocketClient socketClient;

--- a/test/src/com/connectsdk/service/webos/WebOSTVServiceSocketClientTest.java
+++ b/test/src/com/connectsdk/service/webos/WebOSTVServiceSocketClientTest.java
@@ -1,10 +1,9 @@
 package com.connectsdk.service.webos;
 
 
+import com.connectsdk.BuildConfig;
 import com.connectsdk.service.WebOSTVService;
-import com.connectsdk.service.capability.listeners.ResponseListener;
 import com.connectsdk.service.command.ServiceCommand;
-import com.connectsdk.service.command.ServiceCommandError;
 
 import junit.framework.Assert;
 
@@ -12,13 +11,13 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.net.URI;
 
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, sdk = 21)
 public class WebOSTVServiceSocketClientTest {
 
     private WebOSTVServiceSocketClient socketClient;


### PR DESCRIPTION
Consider the situation that there are 2 SDKs (SDK_A and SDK_B) using ConnectSDK. Both of them run DiscoveryManager.init() in their SDK.init() method and told their clients to run it in Application.onCreate(). 2 DiscoveryManager instances will be created in that case, and potentially leaked a DiscoveryManager.

This pull request will make sure there is only one single static instance of DiscoveryManager will be used. Event DiscoveryManager.init() is run twice, only one DiscoveryManager will be used.

Also, making DiscoveryManager's constructor private can prevent clients from creating multiple instances of DiscoveryManager, as it is not recommended already in the original code.
