### PR TITLE
Added support for custom data in the MediaInfo object class + other fix

### DIFF
--- a/src/com/connectsdk/core/MediaInfo.java
+++ b/src/com/connectsdk/core/MediaInfo.java
@@ -39,6 +39,7 @@ public class MediaInfo {
     private String mimeType;
     private String description;
     private String title;
+    private Object customData;
 
     /**
      * list of imageInfo objects where [0] is icon, [1] is poster
@@ -61,6 +62,7 @@ public class MediaInfo {
         private String description;
         private List<ImageInfo> allImages;
         private SubtitleInfo subtitleInfo;
+        private Object customData;
 
         // @endcond
 
@@ -100,6 +102,11 @@ public class MediaInfo {
             return this;
         }
 
+        public Builder setCustomData(@NonNull Object customData) {
+            this.customData = customData;
+            return this;
+        }
+
         public MediaInfo build() {
             return new MediaInfo(this);
         }
@@ -119,6 +126,7 @@ public class MediaInfo {
         description = builder.description;
         subtitleInfo = builder.subtitleInfo;
         allImages = builder.allImages;
+        customData = builder.customData;
     }
 
     /**
@@ -272,6 +280,16 @@ public class MediaInfo {
         List<ImageInfo> list = new ArrayList<ImageInfo>();
         Collections.addAll(list, images);
         this.setImages(list);
+    }
+
+    /** Gets the raw data associated to this MediaInfo. In most cases, this is a Map or JSONObject. */
+    public Object getCustomData() {
+        return customData;
+    }
+
+    /** Sets the raw data associated to this MediaInfo.. In most cases, this is a Map or JSONObject. */
+    public void setCustomData(Object customData) {
+        this.customData = customData;
     }
 
 }

--- a/src/com/connectsdk/device/ConnectableDevice.java
+++ b/src/com/connectsdk/device/ConnectableDevice.java
@@ -131,21 +131,19 @@ public class ConnectableDevice implements DeviceServiceListener {
         setLastDetection(json.optLong(KEY_LAST_DETECTED, 0));
 
         //Deserialize the associated services as well
-        try {
-            JSONObject jsonServices = json.getJSONObject(KEY_SERVICES);
+        JSONObject jsonServices = json.optJSONObject(KEY_SERVICES);
+        if(jsonServices!=null) {
             Iterator<?> keys = jsonServices.keys();
-            if(keys!=null) {
+            if (keys != null) {
                 while (keys.hasNext()) {
                     String key = (String) keys.next();
-                    if (jsonServices.get(key) instanceof JSONObject) {
-                        JSONObject serviceObject = (JSONObject) jsonServices.get(key);
+                    JSONObject serviceObject = jsonServices.optJSONObject(key);
+                    if (serviceObject!=null) {
                         DeviceService service = DeviceService.getService(serviceObject);
                         addService(service);
                     }
                 }
             }
-        } catch (JSONException e) {
-            e.printStackTrace();
         }
 
     }

--- a/src/com/connectsdk/device/ConnectableDevice.java
+++ b/src/com/connectsdk/device/ConnectableDevice.java
@@ -129,6 +129,25 @@ public class ConnectableDevice implements DeviceServiceListener {
         setLastSeenOnWifi(json.optString(KEY_LAST_SEEN, null));
         setLastConnected(json.optLong(KEY_LAST_CONNECTED, 0));
         setLastDetection(json.optLong(KEY_LAST_DETECTED, 0));
+
+        //Deserialize the associated services as well
+        try {
+            JSONObject jsonServices = json.getJSONObject(KEY_SERVICES);
+            Iterator<?> keys = jsonServices.keys();
+            if(keys!=null) {
+                while (keys.hasNext()) {
+                    String key = (String) keys.next();
+                    if (jsonServices.get(key) instanceof JSONObject) {
+                        JSONObject serviceObject = (JSONObject) jsonServices.get(key);
+                        DeviceService service = DeviceService.getService(serviceObject);
+                        addService(service);
+                    }
+                }
+            }
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+
     }
 
     public static ConnectableDevice createFromConfigString(String ipAddress, String friendlyName, String modelName, String modelNumber) {
@@ -816,6 +835,9 @@ public class ConnectableDevice implements DeviceServiceListener {
         setModelName(description.getModelName());
         setModelNumber(description.getModelNumber());
         setLastConnected(description.getLastDetection());
+
+        if(description.getUUID()!=null && description.getUUID().length()>0)
+            setId(description.getUUID());
     }
 
     public JSONObject toJSONObject() {

--- a/src/com/connectsdk/discovery/DiscoveryManager.java
+++ b/src/com/connectsdk/discovery/DiscoveryManager.java
@@ -590,16 +590,16 @@ public class DiscoveryManager implements ConnectableDeviceListener, DiscoveryPro
 
         compatibleDevices.put(device.getIpAddress(), device);
 
-        for (DiscoveryManagerListener listenter: discoveryListeners) {
-            listenter.onDeviceAdded(this, device);
+        for (DiscoveryManagerListener listener: discoveryListeners) {
+            listener.onDeviceAdded(this, device);
         }
     }
 
     public void handleDeviceUpdate(ConnectableDevice device) {
         if (deviceIsCompatible(device)) {
             if (device.getIpAddress() != null && compatibleDevices.containsKey(device.getIpAddress())) {
-                for (DiscoveryManagerListener listenter: discoveryListeners) {
-                    listenter.onDeviceUpdated(this, device);
+                for (DiscoveryManagerListener listener: discoveryListeners) {
+                    listener.onDeviceUpdated(this, device);
                 }
             }
             else {
@@ -613,8 +613,8 @@ public class DiscoveryManager implements ConnectableDeviceListener, DiscoveryPro
     }
 
     public void handleDeviceLoss(ConnectableDevice device) {
-        for (DiscoveryManagerListener listenter: discoveryListeners) {
-            listenter.onDeviceRemoved(this, device);
+        for (DiscoveryManagerListener listener: discoveryListeners) {
+            listener.onDeviceRemoved(this, device);
         }
 
         device.disconnect();
@@ -732,7 +732,6 @@ public class DiscoveryManager implements ConnectableDeviceListener, DiscoveryPro
 
         if (device == null) {
             device = new ConnectableDevice(serviceDescription);
-            device.setIpAddress(serviceDescription.getIpAddress());
             allDevices.put(serviceDescription.getIpAddress(), device);
             deviceIsNew = true;
         }
@@ -850,6 +849,7 @@ public class DiscoveryManager implements ConnectableDeviceListener, DiscoveryPro
         if (deviceService != null) {
             deviceService.setServiceDescription(desc);
             device.addService(deviceService);
+            device.setServiceDescription(desc);
         }
     }
     // @endcond

--- a/src/com/connectsdk/discovery/provider/SSDPDiscoveryProvider.java
+++ b/src/com/connectsdk/discovery/provider/SSDPDiscoveryProvider.java
@@ -208,6 +208,12 @@ public class SSDPDiscoveryProvider implements DiscoveryProvider {
         if (executorService == null || executorService.isShutdown()) {
             Log.w(Util.T, "There are no filters added");
         } else {
+            if (executorService.isTerminated() || executorService.isShutdown()) {
+                if (serviceFilters != null && !serviceFilters.isEmpty()) {
+                    int poolSize = serviceFilters.size() * 3;
+                    executorService = Executors.newScheduledThreadPool(poolSize);
+                }
+            }
             for (DiscoveryFilter filter : serviceFilters) {
                 final String message = SSDPClient.getSSDPSearchMessage(filter.getServiceFilter());
                 /* Send 3 times like WindowsMedia */

--- a/src/com/connectsdk/discovery/provider/SSDPDiscoveryProvider.java
+++ b/src/com/connectsdk/discovery/provider/SSDPDiscoveryProvider.java
@@ -45,6 +45,9 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -70,7 +73,7 @@ public class SSDPDiscoveryProvider implements DiscoveryProvider {
 
     private Thread responseThread;
     private Thread notifyThread;
-
+    private ScheduledExecutorService executorService;
     boolean isRunning = false;
 
     public SSDPDiscoveryProvider(Context context) {
@@ -111,7 +114,11 @@ public class SSDPDiscoveryProvider implements DiscoveryProvider {
         isRunning = true;
 
         openSocket();
-
+        if (serviceFilters != null && !serviceFilters.isEmpty()) {
+            //three tasks for each service filter
+            int poolSize = serviceFilters.size() * 3;
+            executorService = Executors.newScheduledThreadPool(poolSize);
+        }
         scanTimer = new Timer();
         scanTimer.schedule(new TimerTask() {
 
@@ -177,6 +184,10 @@ public class SSDPDiscoveryProvider implements DiscoveryProvider {
             ssdpClient.close();
             ssdpClient = null;
         }
+
+        if (executorService != null && !executorService.isShutdown()) {
+            executorService.shutdown();
+        }
     }
 
     @Override
@@ -194,26 +205,25 @@ public class SSDPDiscoveryProvider implements DiscoveryProvider {
 
     @Override
     public void rescan() {
-        for (DiscoveryFilter searchTarget : serviceFilters) {
-            final String message = SSDPClient.getSSDPSearchMessage(searchTarget.getServiceFilter());
-
-            Timer timer = new Timer();
-            /* Send 3 times like WindowsMedia */
-            for (int i = 0; i < 3; i++) {
-                TimerTask task = new TimerTask() {
-
-                    @Override
-                    public void run() {
-                        try {
-                            if (ssdpClient != null)
-                                ssdpClient.send(message);
-                        } catch (IOException e) {
-                            e.printStackTrace();
+        if (executorService == null || executorService.isShutdown()) {
+            Log.w(Util.T, "There are no filters added");
+        } else {
+            for (DiscoveryFilter filter : serviceFilters) {
+                final String message = SSDPClient.getSSDPSearchMessage(filter.getServiceFilter());
+                /* Send 3 times like WindowsMedia */
+                for (int i = 0; i < 3; i++) {
+                    executorService.schedule(new Runnable() {
+                        @Override
+                        public void run() {
+                            try {
+                                if (ssdpClient != null)
+                                    ssdpClient.send(message);
+                            } catch (IOException ex) {
+                                Log.e(Util.T, ex.getMessage());
+                            }
                         }
-                    }
-                };
-
-                timer.schedule(task, i * 1000);
+                    }, i, TimeUnit.SECONDS);
+                }
             }
         }
 

--- a/src/com/connectsdk/discovery/provider/ZeroconfDiscoveryProvider.java
+++ b/src/com/connectsdk/discovery/provider/ZeroconfDiscoveryProvider.java
@@ -20,6 +20,16 @@
 
 package com.connectsdk.discovery.provider;
 
+import android.content.Context;
+import android.text.TextUtils;
+import android.util.Log;
+
+import com.connectsdk.core.Util;
+import com.connectsdk.discovery.DiscoveryFilter;
+import com.connectsdk.discovery.DiscoveryProvider;
+import com.connectsdk.discovery.DiscoveryProviderListener;
+import com.connectsdk.service.config.ServiceDescription;
+
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -34,15 +44,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import javax.jmdns.JmDNS;
 import javax.jmdns.ServiceEvent;
 import javax.jmdns.ServiceListener;
-
-import android.content.Context;
-import android.util.Log;
-
-import com.connectsdk.core.Util;
-import com.connectsdk.discovery.DiscoveryFilter;
-import com.connectsdk.discovery.DiscoveryProvider;
-import com.connectsdk.discovery.DiscoveryProviderListener;
-import com.connectsdk.service.config.ServiceDescription;
 
 public class ZeroconfDiscoveryProvider implements DiscoveryProvider {
     private static final String HOSTNAME = "connectsdk";
@@ -216,7 +217,9 @@ public class ZeroconfDiscoveryProvider implements DiscoveryProvider {
         if (jmdns != null) {
             for (DiscoveryFilter searchTarget : serviceFilters) {
                 String filter = searchTarget.getServiceFilter();
-                jmdns.removeServiceListener(filter, jmdnsListener);
+                if (!TextUtils.isEmpty(filter)) {
+                    jmdns.removeServiceListener(filter, jmdnsListener);
+                }
             }
         }
     }
@@ -245,7 +248,9 @@ public class ZeroconfDiscoveryProvider implements DiscoveryProvider {
             if (jmdns != null) {
                 for (DiscoveryFilter searchTarget : serviceFilters) {
                     String filter = searchTarget.getServiceFilter();
-                    jmdns.addServiceListener(filter, jmdnsListener);
+                    if (!TextUtils.isEmpty(filter)) {
+                        jmdns.addServiceListener(filter, jmdnsListener);
+                    }
                 }
             }
         } catch (IOException e) {

--- a/src/com/connectsdk/service/AirPlayService.java
+++ b/src/com/connectsdk/service/AirPlayService.java
@@ -494,6 +494,16 @@ public class AirPlayService extends DeviceService implements MediaPlayer, MediaC
 
     @Override
     public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, LaunchListener listener) {
+        playMedia(mediaInfo, shouldLoop, 0, listener);
+    }
+
+    @Override
+    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, long startPosition, LaunchListener listener) {
+        playMedia(mediaInfo, shouldLoop, startPosition, null, listener);
+    }
+
+    @Override
+    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, long startPosition, Object customData, LaunchListener listener) {
         String mediaUrl = null;
         String mimeType = null;
         String title = null;

--- a/src/com/connectsdk/service/DIALService.java
+++ b/src/com/connectsdk/service/DIALService.java
@@ -54,6 +54,7 @@ public class DIALService extends DeviceService implements Launcher {
 
     public static final String ID = "DIAL";
     private static final String APP_NETFLIX = "Netflix";
+    private static final String APP_YOUTUBE = "YouTube";
 
     private static List<String> registeredApps = new ArrayList<String>();
 
@@ -206,9 +207,9 @@ public class DIALService extends DeviceService implements Launcher {
     @Override
     public void launchYouTube(String contentId, float startTime, AppLaunchListener listener) {
         String params = null;
-        AppInfo appInfo = new AppInfo("YouTube");
+        AppInfo appInfo = new AppInfo(APP_YOUTUBE);
         appInfo.setName(appInfo.getId());
-
+        JSONObject jsonParams = null;
         if (contentId != null && contentId.length() > 0) {
             if (startTime < 0.0) {
                 if (listener != null) {
@@ -219,6 +220,16 @@ public class DIALService extends DeviceService implements Launcher {
             }
 
             String pairingCode = java.util.UUID.randomUUID().toString();
+            /*
+            jsonParams = new JSONObject();
+            try {
+                //jsonParams.put("pairingCode", pairingCode);
+                jsonParams.put("v", contentId);
+                jsonParams.put("t", startTime);
+            } catch (JSONException e) {
+                Log.e(Util.T, "Launch YouTube error", e);
+            }
+            */
             params = String.format(Locale.US, "pairingCode=%s&v=%s&t=%.1f", pairingCode, contentId, startTime);
         }
 

--- a/src/com/connectsdk/service/DLNAService.java
+++ b/src/com/connectsdk/service/DLNAService.java
@@ -358,8 +358,17 @@ public class DLNAService extends DeviceService implements PlaylistControl, Media
     }
 
     @Override
-    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop,
-            LaunchListener listener) {
+    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, LaunchListener listener) {
+        playMedia(mediaInfo, shouldLoop, 0, null, listener);
+    }
+
+    @Override
+    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, long startPosition, LaunchListener listener) {
+        playMedia(mediaInfo, shouldLoop, startPosition, null, listener);
+    }
+
+    @Override
+    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, long startPosition, Object customData, LaunchListener listener) {
         String mediaUrl = null;
         SubtitleInfo subtitle = null;
         String mimeType = null;

--- a/src/com/connectsdk/service/NetcastTVService.java
+++ b/src/com/connectsdk/service/NetcastTVService.java
@@ -1558,6 +1558,16 @@ public class NetcastTVService extends DeviceService implements Launcher, MediaCo
 
     @Override
     public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, final MediaPlayer.LaunchListener listener) {
+        playMedia(mediaInfo, shouldLoop, 0, listener);
+    }
+
+    @Override
+    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, long startPosition, LaunchListener listener) {
+        playMedia(mediaInfo, shouldLoop, startPosition, null, listener);
+    }
+
+    @Override
+    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, long startPosition, Object customData, final LaunchListener listener) {
         if (getDLNAService() != null) {
             final MediaPlayer.LaunchListener launchListener = new LaunchListener() {
 

--- a/src/com/connectsdk/service/RokuService.java
+++ b/src/com/connectsdk/service/RokuService.java
@@ -735,8 +735,17 @@ public class RokuService extends DeviceService implements Launcher, MediaPlayer,
     }
 
     @Override
-    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop,
-            MediaPlayer.LaunchListener listener) {
+    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, MediaPlayer.LaunchListener listener) {
+        playMedia(mediaInfo, shouldLoop, 0, listener);
+    }
+
+    @Override
+    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, long startPosition, LaunchListener listener) {
+        playMedia(mediaInfo, shouldLoop, startPosition, null, listener);
+    }
+
+    @Override
+    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, long startPosition, Object customData, LaunchListener listener) {
         String mediaUrl = null;
         String mimeType = null;
         String title = null;

--- a/src/com/connectsdk/service/WebOSTVService.java
+++ b/src/com/connectsdk/service/WebOSTVService.java
@@ -304,6 +304,11 @@ public class WebOSTVService extends DeviceService implements Launcher, MediaCont
         return service;
     }
 
+    @Override
+    public String getWebAppId() {
+        return MEDIA_PLAYER_ID;
+    }
+
     public static DiscoveryFilter discoveryFilter() {
         return new DiscoveryFilter(ID, "urn:lge-com:service:webos-second-screen:1");
     }
@@ -1293,8 +1298,17 @@ public class WebOSTVService extends DeviceService implements Launcher, MediaCont
     }
 
     @Override
-    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop,
-                          MediaPlayer.LaunchListener listener) {
+    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, MediaPlayer.LaunchListener listener) {
+        playMedia(mediaInfo, shouldLoop, 0, listener);
+    }
+
+    @Override
+    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, long startPosition, LaunchListener listener) {
+        playMedia(mediaInfo, shouldLoop, startPosition, null, listener);
+    }
+
+    @Override
+    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, long startPosition, Object customData, LaunchListener listener) {
         if ("4.0.0".equalsIgnoreCase(this.serviceDescription.getVersion())) {
             playMediaByNativeApp(mediaInfo, shouldLoop, listener);
         } else {

--- a/src/com/connectsdk/service/capability/MediaPlayer.java
+++ b/src/com/connectsdk/service/capability/MediaPlayer.java
@@ -25,6 +25,8 @@ import com.connectsdk.service.capability.listeners.ResponseListener;
 import com.connectsdk.service.command.ServiceSubscription;
 import com.connectsdk.service.sessions.LaunchSession;
 
+import org.json.JSONObject;
+
 public interface MediaPlayer extends CapabilityMethods {
     public final static String Any = "MediaPlayer.Any";
 
@@ -81,6 +83,10 @@ public interface MediaPlayer extends CapabilityMethods {
     public void displayImage(MediaInfo mediaInfo, LaunchListener listener);
 
     public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, LaunchListener listener);
+
+    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, long startPosition, LaunchListener listener);
+
+    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, long startPosition, Object customData, LaunchListener listener);
 
     public void closeMedia(LaunchSession launchSession, ResponseListener<Object> listener);
 

--- a/src/com/connectsdk/service/capability/WebAppLauncher.java
+++ b/src/com/connectsdk/service/capability/WebAppLauncher.java
@@ -59,6 +59,7 @@ public interface WebAppLauncher extends CapabilityMethods {
     };
 
     public WebAppLauncher getWebAppLauncher();
+    public String getWebAppId();
     public CapabilityPriorityLevel getWebAppLauncherCapabilityLevel();
 
     public void launchWebApp(String webAppId, LaunchListener listener);

--- a/src/com/connectsdk/service/sessions/WebAppSession.java
+++ b/src/com/connectsdk/service/sessions/WebAppSession.java
@@ -418,8 +418,17 @@ public class WebAppSession implements MediaControl, MediaPlayer, PlaylistControl
     }
 
     @Override
-    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop,
-            MediaPlayer.LaunchListener listener) {
+    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, MediaPlayer.LaunchListener listener) {
+        Util.postError(listener, ServiceCommandError.notSupported());
+    }
+
+    @Override
+    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, long startPosition, MediaPlayer.LaunchListener listener) {
+        Util.postError(listener, ServiceCommandError.notSupported());
+    }
+
+    @Override
+    public void playMedia(MediaInfo mediaInfo, boolean shouldLoop, long startPosition, Object customData, MediaPlayer.LaunchListener listener) {
         Util.postError(listener, ServiceCommandError.notSupported());
     }
 

--- a/test/src/com/connectsdk/core/MediaInfoTest.java
+++ b/test/src/com/connectsdk/core/MediaInfoTest.java
@@ -23,6 +23,8 @@ import com.connectsdk.BuildConfig;
 
 import junit.framework.Assert;
 
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricGradleTestRunner;
@@ -54,6 +56,14 @@ public class MediaInfoTest {
         String mimeType = "video/mp4";
         String description = "description";
         String iconUrl = "http://iconurl";
+        JSONObject customData = new JSONObject(){{
+            try {
+                put("data1", 1);
+                put("data2", 2);
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+        }};
 
         SubtitleInfo subtitle = new SubtitleInfo.Builder("").build();
         String title = "title";
@@ -63,6 +73,7 @@ public class MediaInfoTest {
                 .setIcon(iconUrl)
                 .setSubtitleInfo(subtitle)
                 .setTitle(title)
+                .setCustomData(customData)
                 .build();
 
         Assert.assertEquals(url, mediaInfo.getUrl());
@@ -72,6 +83,7 @@ public class MediaInfoTest {
         Assert.assertEquals(1, mediaInfo.getImages().size());
         Assert.assertEquals(subtitle, mediaInfo.getSubtitleInfo());
         Assert.assertEquals(title, mediaInfo.getTitle());
+        Assert.assertEquals(customData, mediaInfo.getCustomData());
     }
 
     @Test

--- a/test/src/com/connectsdk/core/MediaInfoTest.java
+++ b/test/src/com/connectsdk/core/MediaInfoTest.java
@@ -19,16 +19,18 @@
  */
 package com.connectsdk.core;
 
+import com.connectsdk.BuildConfig;
+
 import junit.framework.Assert;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
 
 
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, sdk = 21)
 public class MediaInfoTest {
 
     @Test

--- a/test/src/com/connectsdk/core/MediaInfoTest.java
+++ b/test/src/com/connectsdk/core/MediaInfoTest.java
@@ -26,8 +26,9 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE)
+
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class)
 public class MediaInfoTest {
 
     @Test

--- a/test/src/com/connectsdk/core/SubtitleInfoTest.java
+++ b/test/src/com/connectsdk/core/SubtitleInfoTest.java
@@ -27,8 +27,8 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE)
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class)
 public class SubtitleInfoTest {
 
     @Test

--- a/test/src/com/connectsdk/core/SubtitleInfoTest.java
+++ b/test/src/com/connectsdk/core/SubtitleInfoTest.java
@@ -19,16 +19,18 @@
  */
 package com.connectsdk.core;
 
+import com.connectsdk.BuildConfig;
+
 import junit.framework.Assert;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
 
 
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, sdk = 21)
 public class SubtitleInfoTest {
 
     @Test

--- a/test/src/com/connectsdk/device/ConnectableDeviceTest.java
+++ b/test/src/com/connectsdk/device/ConnectableDeviceTest.java
@@ -1,5 +1,6 @@
 package com.connectsdk.device;
 
+import com.connectsdk.BuildConfig;
 import com.connectsdk.discovery.DiscoveryManager;
 import com.connectsdk.service.AirPlayService;
 import com.connectsdk.service.DIALService;
@@ -19,8 +20,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 import java.io.IOException;
@@ -28,14 +29,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, sdk = 21)
 public class ConnectableDeviceTest {
 
     private ConnectableDevice device;
 
     @Before
     public void setUp() {
-        DiscoveryManager.init(Robolectric.application);
+        DiscoveryManager.init(RuntimeEnvironment.application);
         device = new ConnectableDevice();
     }
 

--- a/test/src/com/connectsdk/device/ConnectableDeviceTest.java
+++ b/test/src/com/connectsdk/device/ConnectableDeviceTest.java
@@ -27,8 +27,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE)
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class)
 public class ConnectableDeviceTest {
 
     private ConnectableDevice device;

--- a/test/src/com/connectsdk/discovery/DiscoveryManagerTest.java
+++ b/test/src/com/connectsdk/discovery/DiscoveryManagerTest.java
@@ -1,5 +1,6 @@
 package com.connectsdk.discovery;
 
+import com.connectsdk.BuildConfig;
 import com.connectsdk.discovery.provider.SSDPDiscoveryProvider;
 import com.connectsdk.discovery.provider.ZeroconfDiscoveryProvider;
 import com.connectsdk.service.DIALService;
@@ -10,8 +11,8 @@ import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 import java.util.Objects;
@@ -21,14 +22,14 @@ import java.util.Objects;
  */
 
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, sdk = 21)
 public class DiscoveryManagerTest {
     
     DiscoveryManager discovery;
     
     @Before
     public void setUp() {
-        discovery = new DiscoveryManager(Robolectric.application);
+        discovery = new DiscoveryManager(RuntimeEnvironment.application);
     }
     
     @Test
@@ -48,7 +49,7 @@ public class DiscoveryManagerTest {
 
     @Test
     public void testUnregisterDeviceServiceWithWrongProvider() {
-        discovery.discoveryProviders.add(new SSDPDiscoveryProvider(Robolectric.application));
+        discovery.discoveryProviders.add(new SSDPDiscoveryProvider(RuntimeEnvironment.application));
         discovery.deviceClasses.put(DIALService.ID, DIALService.class);
         Assert.assertEquals(1, discovery.discoveryProviders.size());
         Assert.assertEquals(1, discovery.deviceClasses.size());
@@ -60,7 +61,7 @@ public class DiscoveryManagerTest {
 
     @Test
     public void testUnregisterDeviceServiceWithWrongServiceID() {
-        discovery.discoveryProviders.add(new SSDPDiscoveryProvider(Robolectric.application));
+        discovery.discoveryProviders.add(new SSDPDiscoveryProvider(RuntimeEnvironment.application));
         discovery.deviceClasses.put(DLNAService.ID, DIALService.class);
         Assert.assertEquals(1, discovery.discoveryProviders.size());
         Assert.assertEquals(1, discovery.deviceClasses.size());
@@ -72,7 +73,7 @@ public class DiscoveryManagerTest {
     
     @Test
     public void testUnregisterDeviceService() {
-        discovery.discoveryProviders.add(new SSDPDiscoveryProvider(Robolectric.application));
+        discovery.discoveryProviders.add(new SSDPDiscoveryProvider(RuntimeEnvironment.application));
         discovery.deviceClasses.put(DIALService.ID, DIALService.class);
         Assert.assertEquals(1, discovery.discoveryProviders.size());
         Assert.assertEquals(1, discovery.deviceClasses.size());

--- a/test/src/com/connectsdk/discovery/DiscoveryManagerTest.java
+++ b/test/src/com/connectsdk/discovery/DiscoveryManagerTest.java
@@ -20,8 +20,8 @@ import java.util.Objects;
  * Created by oleksii.frolov on 2/16/2015.
  */
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest=Config.NONE)
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class)
 public class DiscoveryManagerTest {
     
     DiscoveryManager discovery;

--- a/test/src/com/connectsdk/discovery/provider/SSDPDiscoveryProviderTest.java
+++ b/test/src/com/connectsdk/discovery/provider/SSDPDiscoveryProviderTest.java
@@ -30,8 +30,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest=Config.NONE,shadows={WifiInfoShadow.class})
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class, shadows={WifiInfoShadow.class})
 public class SSDPDiscoveryProviderTest{
 
 

--- a/test/src/com/connectsdk/discovery/provider/SSDPDiscoveryProviderTest.java
+++ b/test/src/com/connectsdk/discovery/provider/SSDPDiscoveryProviderTest.java
@@ -38,7 +38,7 @@ public class SSDPDiscoveryProviderTest{
     SSDPDiscoveryProvider dp;
     private SSDPClient ssdpClient = Mockito.mock(SSDPClient.class);
 
-    class StubSSDPDiscoveryProvider extends SSDPDiscoveryProvider {
+        class StubSSDPDiscoveryProvider extends SSDPDiscoveryProvider {
 
         public StubSSDPDiscoveryProvider(Context context) {
             super(context);

--- a/test/src/com/connectsdk/discovery/provider/SSDPDiscoveryProviderTest.java
+++ b/test/src/com/connectsdk/discovery/provider/SSDPDiscoveryProviderTest.java
@@ -2,6 +2,7 @@ package com.connectsdk.discovery.provider;
 
 import android.content.Context;
 
+import com.connectsdk.BuildConfig;
 import com.connectsdk.core.TestUtil;
 import com.connectsdk.discovery.DiscoveryFilter;
 import com.connectsdk.discovery.provider.ssdp.SSDPClient;
@@ -14,10 +15,9 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 import java.io.IOException;
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class, shadows={WifiInfoShadow.class})
+@Config(constants = BuildConfig.class, shadows={WifiInfoShadow.class}, sdk = 21)
 public class SSDPDiscoveryProviderTest{
 
 
@@ -57,7 +57,7 @@ public class SSDPDiscoveryProviderTest{
         byte[] data = new byte[1];
         when(ssdpClient.responseReceive()).thenReturn(new DatagramPacket(data, 1));
         when(ssdpClient.multicastReceive()).thenReturn(new DatagramPacket(data, 1));
-        dp = new StubSSDPDiscoveryProvider(Robolectric.application);
+        dp = new StubSSDPDiscoveryProvider(RuntimeEnvironment.application);
         assertNotNull(dp);
     }
     @After

--- a/test/src/com/connectsdk/discovery/provider/ZeroConfDiscoveryPrividerTest.java
+++ b/test/src/com/connectsdk/discovery/provider/ZeroConfDiscoveryPrividerTest.java
@@ -34,9 +34,8 @@ import com.connectsdk.discovery.DiscoveryProvider;
 import com.connectsdk.discovery.DiscoveryProviderListener;
 import com.connectsdk.service.config.ServiceDescription;
 import com.connectsdk.shadow.WifiInfoShadow;
-
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, shadows = { WifiInfoShadow.class })
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class, shadows = {WifiInfoShadow.class })
 public class ZeroConfDiscoveryPrividerTest {
 
     private ZeroconfDiscoveryProvider dp;

--- a/test/src/com/connectsdk/discovery/provider/ZeroConfDiscoveryPrividerTest.java
+++ b/test/src/com/connectsdk/discovery/provider/ZeroConfDiscoveryPrividerTest.java
@@ -1,12 +1,24 @@
 package com.connectsdk.discovery.provider;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import android.content.Context;
+
+import com.connectsdk.BuildConfig;
+import com.connectsdk.discovery.DiscoveryFilter;
+import com.connectsdk.discovery.DiscoveryManager;
+import com.connectsdk.discovery.DiscoveryProvider;
+import com.connectsdk.discovery.DiscoveryProviderListener;
+import com.connectsdk.service.config.ServiceDescription;
+import com.connectsdk.shadow.WifiInfoShadow;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowLooper;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -17,25 +29,15 @@ import javax.jmdns.ServiceInfo;
 import javax.jmdns.ServiceListener;
 import javax.jmdns.impl.JmDNSImpl;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mockito;
-import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
-
-import android.content.Context;
-
-import com.connectsdk.discovery.DiscoveryFilter;
-import com.connectsdk.discovery.DiscoveryManager;
-import com.connectsdk.discovery.DiscoveryProvider;
-import com.connectsdk.discovery.DiscoveryProviderListener;
-import com.connectsdk.service.config.ServiceDescription;
-import com.connectsdk.shadow.WifiInfoShadow;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class, shadows = {WifiInfoShadow.class })
+@Config(constants = BuildConfig.class, shadows = {WifiInfoShadow.class }, sdk = 21)
 public class ZeroConfDiscoveryPrividerTest {
 
     private ZeroconfDiscoveryProvider dp;
@@ -77,7 +79,7 @@ public class ZeroConfDiscoveryPrividerTest {
 
     @Before
     public void setUp() {
-        dp = new StubZeroConfDiscoveryProvider(Robolectric.application);
+        dp = new StubZeroConfDiscoveryProvider(RuntimeEnvironment.application);
         mDNS = mock(StubJmDNS.class);
         eventMock = mock(StubServiceEvent.class);
 
@@ -296,7 +298,7 @@ public class ZeroConfDiscoveryPrividerTest {
 
         // when
         dp.jmdnsListener.serviceRemoved(event);
-        Robolectric.runUiThreadTasksIncludingDelayedTasks();
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
 
         // then
         verify(listener).onServiceRemoved(any(DiscoveryProvider.class), any(ServiceDescription.class));

--- a/test/src/com/connectsdk/discovery/provider/ssdp/SSDPClientTest.java
+++ b/test/src/com/connectsdk/discovery/provider/ssdp/SSDPClientTest.java
@@ -22,8 +22,8 @@ import java.net.MulticastSocket;
 import java.net.NetworkInterface;
 import java.net.SocketAddress;
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest=Config.NONE ,shadows = { WifiInfoShadow.class })
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class, shadows = { WifiInfoShadow.class })
 public class SSDPClientTest {
 
     InetAddress localAddress;

--- a/test/src/com/connectsdk/discovery/provider/ssdp/SSDPClientTest.java
+++ b/test/src/com/connectsdk/discovery/provider/ssdp/SSDPClientTest.java
@@ -1,5 +1,6 @@
 package com.connectsdk.discovery.provider.ssdp;
 
+import com.connectsdk.BuildConfig;
 import com.connectsdk.core.Util;
 import com.connectsdk.shadow.WifiInfoShadow;
 
@@ -9,8 +10,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 import java.io.IOException;
@@ -23,7 +24,7 @@ import java.net.NetworkInterface;
 import java.net.SocketAddress;
 
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class, shadows = { WifiInfoShadow.class })
+@Config(constants = BuildConfig.class, shadows = { WifiInfoShadow.class }, sdk = 21)
 public class SSDPClientTest {
 
     InetAddress localAddress;
@@ -38,7 +39,7 @@ public class SSDPClientTest {
 
     @Before
     public void setUp() throws IOException {
-        localAddress = Util.getIpAddress(Robolectric.application);
+        localAddress = Util.getIpAddress(RuntimeEnvironment.application);
         ssdpClient = new SSDPClient(localAddress, mLocalSocket, wildSocket);
     }
 

--- a/test/src/com/connectsdk/discovery/provider/ssdp/SSDPDeviceTest.java
+++ b/test/src/com/connectsdk/discovery/provider/ssdp/SSDPDeviceTest.java
@@ -9,6 +9,7 @@ import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
 import java.io.IOException;
+import java.net.ConnectException;
 import java.net.MalformedURLException;
 import java.net.UnknownHostException;
 
@@ -84,7 +85,7 @@ public class SSDPDeviceTest {
         try {
             new SSDPDevice("http://unknown.host", null);
             Assert.fail("MalformedURLException should be thrown");
-        } catch (UnknownHostException e) {
+        } catch (UnknownHostException | ConnectException e) {
             // OK
         } catch (Exception e) {
             Assert.fail("MalformedURLException should be thrown");

--- a/test/src/com/connectsdk/discovery/provider/ssdp/SSDPPacketTest.java
+++ b/test/src/com/connectsdk/discovery/provider/ssdp/SSDPPacketTest.java
@@ -1,16 +1,18 @@
 package com.connectsdk.discovery.provider.ssdp;
 
+import com.connectsdk.BuildConfig;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.net.DatagramPacket;
 
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, sdk = 21)
 public class SSDPPacketTest {
 
     DatagramPacket mDatagramPacket;

--- a/test/src/com/connectsdk/discovery/provider/ssdp/SSDPPacketTest.java
+++ b/test/src/com/connectsdk/discovery/provider/ssdp/SSDPPacketTest.java
@@ -9,8 +9,8 @@ import org.robolectric.annotation.Config;
 
 import java.net.DatagramPacket;
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest=Config.NONE)
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class)
 public class SSDPPacketTest {
 
     DatagramPacket mDatagramPacket;

--- a/test/src/com/connectsdk/service/AirPlayServiceTest.java
+++ b/test/src/com/connectsdk/service/AirPlayServiceTest.java
@@ -20,8 +20,8 @@ import java.io.IOException;
 /**
  * Created by Oleksii Frolov on 3/19/2015.
  */
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE)
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class)
 public class AirPlayServiceTest {
 
     private StubAirPlayService service;

--- a/test/src/com/connectsdk/service/AirPlayServiceTest.java
+++ b/test/src/com/connectsdk/service/AirPlayServiceTest.java
@@ -1,5 +1,6 @@
 package com.connectsdk.service;
 
+import com.connectsdk.BuildConfig;
 import com.connectsdk.service.capability.MediaControl;
 import com.connectsdk.service.command.ServiceCommand;
 import com.connectsdk.service.command.ServiceCommandError;
@@ -12,7 +13,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.io.IOException;
@@ -21,7 +22,7 @@ import java.io.IOException;
  * Created by Oleksii Frolov on 3/19/2015.
  */
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, sdk = 21)
 public class AirPlayServiceTest {
 
     private StubAirPlayService service;

--- a/test/src/com/connectsdk/service/DIALServiceSendCommandTest.java
+++ b/test/src/com/connectsdk/service/DIALServiceSendCommandTest.java
@@ -41,9 +41,8 @@ import org.robolectric.annotation.Config;
 
 import java.io.IOException;
 
-
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE)
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class)
 public class DIALServiceSendCommandTest {
 
     public static final String COMMAND_URL = "http://host:8080/path";

--- a/test/src/com/connectsdk/service/DIALServiceSendCommandTest.java
+++ b/test/src/com/connectsdk/service/DIALServiceSendCommandTest.java
@@ -20,6 +20,7 @@
 
 package com.connectsdk.service;
 
+import com.connectsdk.BuildConfig;
 import com.connectsdk.core.TestUtil;
 import com.connectsdk.etc.helper.HttpConnection;
 import com.connectsdk.etc.helper.HttpMessage;
@@ -35,14 +36,14 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowLooper;
 
 import java.io.IOException;
 
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, sdk = 21)
 public class DIALServiceSendCommandTest {
 
     public static final String COMMAND_URL = "http://host:8080/path";
@@ -150,7 +151,7 @@ public class DIALServiceSendCommandTest {
 
         service.sendCommand(command);
         TestUtil.runUtilBackgroundTasks();
-        Robolectric.runUiThreadTasksIncludingDelayedTasks();
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
 
         Mockito.verify(listener).onSuccess(Mockito.eq(response));
     }
@@ -166,7 +167,7 @@ public class DIALServiceSendCommandTest {
 
         service.sendCommand(command);
         TestUtil.runUtilBackgroundTasks();
-        Robolectric.runUiThreadTasksIncludingDelayedTasks();
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
 
         Mockito.verify(listener).onSuccess(Mockito.eq(response));
     }
@@ -196,7 +197,7 @@ public class DIALServiceSendCommandTest {
 
         service.sendCommand(command);
         TestUtil.runUtilBackgroundTasks();
-        Robolectric.runUiThreadTasksIncludingDelayedTasks();
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
 
         Mockito.verify(listener).onError(Mockito.any(ServiceCommandError.class));
     }

--- a/test/src/com/connectsdk/service/DIALServiceTest.java
+++ b/test/src/com/connectsdk/service/DIALServiceTest.java
@@ -20,6 +20,7 @@
 
 package com.connectsdk.service;
 
+import com.connectsdk.BuildConfig;
 import com.connectsdk.service.capability.Launcher;
 import com.connectsdk.service.command.ServiceCommand;
 import com.connectsdk.service.config.ServiceConfig;
@@ -32,11 +33,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, sdk = 21)
 public class DIALServiceTest {
 
     private static final String APPLICATION_URL = "http://applicationurl";

--- a/test/src/com/connectsdk/service/DIALServiceTest.java
+++ b/test/src/com/connectsdk/service/DIALServiceTest.java
@@ -35,8 +35,8 @@ import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest=Config.NONE)
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class)
 public class DIALServiceTest {
 
     private static final String APPLICATION_URL = "http://applicationurl";

--- a/test/src/com/connectsdk/service/DLNAServiceSendCommandTest.java
+++ b/test/src/com/connectsdk/service/DLNAServiceSendCommandTest.java
@@ -22,6 +22,7 @@ package com.connectsdk.service;
 
 import com.connectsdk.BuildConfig;
 import com.connectsdk.core.TestUtil;
+import com.connectsdk.discovery.DiscoveryManager;
 import com.connectsdk.etc.helper.HttpConnection;
 import com.connectsdk.service.capability.listeners.ResponseListener;
 import com.connectsdk.service.command.ServiceCommand;
@@ -36,6 +37,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLooper;
 
@@ -69,6 +71,7 @@ public class DLNAServiceSendCommandTest {
 
     @Before
     public void setUp() {
+        DiscoveryManager.init(RuntimeEnvironment.application);
         httpConnection = Mockito.mock(HttpConnection.class);
         service = new StubDLNAService(Mockito.mock(ServiceDescription.class),
                 Mockito.mock(ServiceConfig.class));

--- a/test/src/com/connectsdk/service/DLNAServiceSendCommandTest.java
+++ b/test/src/com/connectsdk/service/DLNAServiceSendCommandTest.java
@@ -42,8 +42,8 @@ import org.robolectric.annotation.Config;
 import java.io.IOException;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE)
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class)
 public class DLNAServiceSendCommandTest {
 
     public static final String COMMAND_URL = "http://host:8080/path";

--- a/test/src/com/connectsdk/service/DLNAServiceSendCommandTest.java
+++ b/test/src/com/connectsdk/service/DLNAServiceSendCommandTest.java
@@ -20,9 +20,9 @@
 
 package com.connectsdk.service;
 
+import com.connectsdk.BuildConfig;
 import com.connectsdk.core.TestUtil;
 import com.connectsdk.etc.helper.HttpConnection;
-import com.connectsdk.etc.helper.HttpMessage;
 import com.connectsdk.service.capability.listeners.ResponseListener;
 import com.connectsdk.service.command.ServiceCommand;
 import com.connectsdk.service.command.ServiceCommandError;
@@ -35,15 +35,15 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowLooper;
 
 import java.io.IOException;
 
 
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, sdk = 21)
 public class DLNAServiceSendCommandTest {
 
     public static final String COMMAND_URL = "http://host:8080/path";
@@ -104,7 +104,7 @@ public class DLNAServiceSendCommandTest {
 
         service.sendCommand(command);
         TestUtil.runUtilBackgroundTasks();
-        Robolectric.runUiThreadTasksIncludingDelayedTasks();
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
 
         Mockito.verify(httpConnection, Mockito.times(0)).execute();
         Mockito.verify(listener).onError(Mockito.any(ServiceCommandError.class));
@@ -121,7 +121,7 @@ public class DLNAServiceSendCommandTest {
 
         service.sendCommand(command);
         TestUtil.runUtilBackgroundTasks();
-        Robolectric.runUiThreadTasksIncludingDelayedTasks();
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
 
         Mockito.verify(httpConnection, Mockito.times(0)).execute();
         Mockito.verify(listener).onError(Mockito.any(ServiceCommandError.class));

--- a/test/src/com/connectsdk/service/DLNAServiceTest.java
+++ b/test/src/com/connectsdk/service/DLNAServiceTest.java
@@ -30,8 +30,8 @@ import java.util.Map;
 /**
  * Created by oleksii.frolov on 1/13/2015.
  */
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest=Config.NONE)
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class)
 public class DLNAServiceTest {
 
     private DLNAService service;

--- a/test/src/com/connectsdk/service/DLNAServiceTest.java
+++ b/test/src/com/connectsdk/service/DLNAServiceTest.java
@@ -1,5 +1,6 @@
 package com.connectsdk.service;
 
+import com.connectsdk.BuildConfig;
 import com.connectsdk.core.SubtitleInfo;
 import com.connectsdk.core.TestUtil;
 import com.connectsdk.discovery.provider.ssdp.Service;
@@ -15,8 +16,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 import org.xml.sax.SAXException;
 
@@ -31,7 +32,7 @@ import java.util.Map;
  * Created by oleksii.frolov on 1/13/2015.
  */
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, sdk = 21)
 public class DLNAServiceTest {
 
     private DLNAService service;
@@ -42,7 +43,7 @@ public class DLNAServiceTest {
     public void setUp() {
         dlnaServer = Mockito.mock(DLNAHttpServer.class);
         service = new DLNAService(Mockito.mock(ServiceDescription.class),
-                Mockito.mock(ServiceConfig.class), Robolectric.application, dlnaServer);
+                Mockito.mock(ServiceConfig.class), RuntimeEnvironment.application, dlnaServer);
     }
 
     @Test
@@ -446,7 +447,7 @@ public class DLNAServiceTest {
 
         ServiceDescription description = Mockito.mock(ServiceDescription.class);
         Mockito.when(description.getServiceList()).thenReturn(services);
-        return new DLNAService(description, Mockito.mock(ServiceConfig.class), Robolectric.application, null);
+        return new DLNAService(description, Mockito.mock(ServiceConfig.class), RuntimeEnvironment.application, null);
     }
 
     private void assertXMLEquals(String expectedXML, String actualXML) throws SAXException, IOException {

--- a/test/src/com/connectsdk/service/NetCastTVServiceTest.java
+++ b/test/src/com/connectsdk/service/NetCastTVServiceTest.java
@@ -22,8 +22,8 @@ import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE)
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class)
 public class NetCastTVServiceTest {
 
     private NetcastTVService service;

--- a/test/src/com/connectsdk/service/NetCastTVServiceTest.java
+++ b/test/src/com/connectsdk/service/NetCastTVServiceTest.java
@@ -1,12 +1,12 @@
 package com.connectsdk.service;
 
+import com.connectsdk.BuildConfig;
 import com.connectsdk.discovery.DiscoveryManager;
 import com.connectsdk.service.capability.CapabilityMethods;
 import com.connectsdk.service.capability.MediaControl;
 import com.connectsdk.service.capability.MediaPlayer;
 import com.connectsdk.service.capability.listeners.ResponseListener;
 import com.connectsdk.service.command.NotSupportedServiceCommandError;
-import com.connectsdk.service.command.ServiceCommand;
 import com.connectsdk.service.command.ServiceCommandError;
 import com.connectsdk.service.config.ServiceConfig;
 import com.connectsdk.service.config.ServiceDescription;
@@ -18,12 +18,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, sdk = 21)
 public class NetCastTVServiceTest {
 
     private NetcastTVService service;
@@ -135,7 +135,7 @@ public class NetCastTVServiceTest {
     }
 
     private void setPairingLevel(DiscoveryManager.PairingLevel level) {
-        DiscoveryManager.init(Robolectric.application);
+        DiscoveryManager.init(RuntimeEnvironment.application);
         DiscoveryManager.getInstance().setPairingLevel(level);
     }
 

--- a/test/src/com/connectsdk/service/RokuServiceTest.java
+++ b/test/src/com/connectsdk/service/RokuServiceTest.java
@@ -35,8 +35,8 @@ import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE)
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class)
 public class RokuServiceTest {
 
     private StubRokuService service;

--- a/test/src/com/connectsdk/service/RokuServiceTest.java
+++ b/test/src/com/connectsdk/service/RokuServiceTest.java
@@ -19,6 +19,7 @@
  */
 package com.connectsdk.service;
 
+import com.connectsdk.BuildConfig;
 import com.connectsdk.core.MediaInfo;
 import com.connectsdk.core.TestUtil;
 import com.connectsdk.service.capability.MediaPlayer;
@@ -32,11 +33,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, sdk = 21)
 public class RokuServiceTest {
 
     private StubRokuService service;

--- a/test/src/com/connectsdk/service/WebOSTVServiceTest.java
+++ b/test/src/com/connectsdk/service/WebOSTVServiceTest.java
@@ -19,6 +19,7 @@
  */
 package com.connectsdk.service;
 
+import com.connectsdk.BuildConfig;
 import com.connectsdk.core.ChannelInfo;
 import com.connectsdk.core.MediaInfo;
 import com.connectsdk.core.SubtitleInfo;
@@ -47,9 +48,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowLooper;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -57,7 +58,7 @@ import java.util.List;
 import java.util.Map;
 
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, sdk = 21)
 public class WebOSTVServiceTest {
 
     private WebOSTVService service;
@@ -452,7 +453,7 @@ public class WebOSTVServiceTest {
         // run join success
         ResponseListener webAppListener = argListener.getValue();
         webAppListener.onSuccess(null);
-        Robolectric.runUiThreadTasksIncludingDelayedTasks();
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
 
         // should delegate playing media to the WebAppSession
         ArgumentCaptor<MediaInfo> argMediaInfo = ArgumentCaptor.forClass(MediaInfo.class);

--- a/test/src/com/connectsdk/service/WebOSTVServiceTest.java
+++ b/test/src/com/connectsdk/service/WebOSTVServiceTest.java
@@ -56,8 +56,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest=Config.NONE)
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class)
 public class WebOSTVServiceTest {
 
     private WebOSTVService service;

--- a/test/src/com/connectsdk/service/airplay/PListParserTest.java
+++ b/test/src/com/connectsdk/service/airplay/PListParserTest.java
@@ -19,13 +19,15 @@
  */
 package com.connectsdk.service.airplay;
 
+import com.connectsdk.BuildConfig;
+
 import junit.framework.Assert;
 
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
 import org.xmlpull.v1.XmlPullParserException;
 
@@ -33,7 +35,7 @@ import java.io.IOException;
 
 
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, sdk = 21)
 public class PListParserTest {
 
     @Test

--- a/test/src/com/connectsdk/service/airplay/PListParserTest.java
+++ b/test/src/com/connectsdk/service/airplay/PListParserTest.java
@@ -32,8 +32,8 @@ import org.xmlpull.v1.XmlPullParserException;
 import java.io.IOException;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest=Config.NONE)
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class)
 public class PListParserTest {
 
     @Test

--- a/test/src/com/connectsdk/service/sessions/WebOSWebAppSessionTest.java
+++ b/test/src/com/connectsdk/service/sessions/WebOSWebAppSessionTest.java
@@ -47,8 +47,8 @@ import org.robolectric.annotation.Config;
 
 import android.support.annotation.NonNull;
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest=Config.NONE)
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class)
 public class WebOSWebAppSessionTest {
 
     private WebOSWebAppSession session;

--- a/test/src/com/connectsdk/service/sessions/WebOSWebAppSessionTest.java
+++ b/test/src/com/connectsdk/service/sessions/WebOSWebAppSessionTest.java
@@ -19,6 +19,9 @@
  */
 package com.connectsdk.service.sessions;
 
+import android.support.annotation.NonNull;
+
+import com.connectsdk.BuildConfig;
 import com.connectsdk.core.MediaInfo;
 import com.connectsdk.core.SubtitleInfo;
 import com.connectsdk.service.DeviceService;
@@ -41,14 +44,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
-
-import android.support.annotation.NonNull;
+import org.robolectric.shadows.ShadowLooper;
 
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, sdk = 21)
 public class WebOSWebAppSessionTest {
 
     private WebOSWebAppSession session;
@@ -73,7 +74,7 @@ public class WebOSWebAppSessionTest {
         ResponseListener<Object> listener = Mockito.mock(ResponseListener.class);
         session.previous(listener);
 
-        Robolectric.runUiThreadTasksIncludingDelayedTasks();
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
         ArgumentCaptor<JSONObject> argPacket = ArgumentCaptor.forClass(JSONObject.class);
         ArgumentCaptor<JSONObject> argPayload = ArgumentCaptor.forClass(JSONObject.class);
         Mockito.verify(socket).sendMessage(argPacket.capture(), argPayload.capture());
@@ -94,7 +95,7 @@ public class WebOSWebAppSessionTest {
         ResponseListener<Object> listener = Mockito.mock(ResponseListener.class);
         session.next(listener);
 
-        Robolectric.runUiThreadTasksIncludingDelayedTasks();
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
         ArgumentCaptor<JSONObject> argPacket = ArgumentCaptor.forClass(JSONObject.class);
         ArgumentCaptor<JSONObject> argPayload = ArgumentCaptor.forClass(JSONObject.class);
         Mockito.verify(socket).sendMessage(argPacket.capture(), argPayload.capture());
@@ -115,7 +116,7 @@ public class WebOSWebAppSessionTest {
         ResponseListener<Object> listener = Mockito.mock(ResponseListener.class);
         session.jumpToTrack(7, listener);
 
-        Robolectric.runUiThreadTasksIncludingDelayedTasks();
+        ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
         ArgumentCaptor<JSONObject> argPacket = ArgumentCaptor.forClass(JSONObject.class);
         ArgumentCaptor<JSONObject> argPayload = ArgumentCaptor.forClass(JSONObject.class);
         Mockito.verify(socket).sendMessage(argPacket.capture(), argPayload.capture());

--- a/test/src/com/connectsdk/service/upnp/DLNAHttpServerTest.java
+++ b/test/src/com/connectsdk/service/upnp/DLNAHttpServerTest.java
@@ -1,19 +1,20 @@
 package com.connectsdk.service.upnp;
 
+import com.connectsdk.BuildConfig;
 import com.connectsdk.service.command.URLServiceSubscription;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
 
 /**
  * Created by oleksii on 4/27/15.
  */
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, sdk = 21)
 public class DLNAHttpServerTest {
 
     DLNAHttpServer server;

--- a/test/src/com/connectsdk/service/upnp/DLNAHttpServerTest.java
+++ b/test/src/com/connectsdk/service/upnp/DLNAHttpServerTest.java
@@ -12,8 +12,8 @@ import org.robolectric.annotation.Config;
 /**
  * Created by oleksii on 4/27/15.
  */
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest=Config.NONE)
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class)
 public class DLNAHttpServerTest {
 
     DLNAHttpServer server;

--- a/test/src/com/connectsdk/service/webos/WebOSTVServiceSocketClientTest.java
+++ b/test/src/com/connectsdk/service/webos/WebOSTVServiceSocketClientTest.java
@@ -17,8 +17,8 @@ import org.robolectric.annotation.Config;
 
 import java.net.URI;
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE)
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class)
 public class WebOSTVServiceSocketClientTest {
 
     private WebOSTVServiceSocketClient socketClient;

--- a/test/src/com/connectsdk/service/webos/WebOSTVServiceSocketClientTest.java
+++ b/test/src/com/connectsdk/service/webos/WebOSTVServiceSocketClientTest.java
@@ -1,10 +1,9 @@
 package com.connectsdk.service.webos;
 
 
+import com.connectsdk.BuildConfig;
 import com.connectsdk.service.WebOSTVService;
-import com.connectsdk.service.capability.listeners.ResponseListener;
 import com.connectsdk.service.command.ServiceCommand;
-import com.connectsdk.service.command.ServiceCommandError;
 
 import junit.framework.Assert;
 
@@ -12,13 +11,13 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.net.URI;
 
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, sdk = 21)
 public class WebOSTVServiceSocketClientTest {
 
     private WebOSTVServiceSocketClient socketClient;


### PR DESCRIPTION
Make sure the ConnectableDevice id is set with the serviceDescription UUID if any, instead of a generated one.
Fix the ConnectableDevice constructor with a JSONObject as argument to properly initialize the serialized DeviceServices if any.
Fix a bug where the serviceDescription does not get set to the ConnectableDevice when first discovered (was only set on the DeviceService at first, and then on the ConnectableDevice, when it get updated).
Added Support for startPosition and customData parameters in playMedia method of MediaPlayer capability.
